### PR TITLE
Faster geo queries and UnIndex catalog searches.

### DIFF
--- a/eggs/Naaya/Products/NaayaCore/CatalogTool/configure.zcml
+++ b/eggs/Naaya/Products/NaayaCore/CatalogTool/configure.zcml
@@ -3,6 +3,9 @@
 
   <naaya:call factory=".CatalogTool.patch_zope_catalog_indexing" />
 
+  <!-- Faster UnIndex searches -->
+  <naaya:call factory=".patch_unindex_apply_index.patch_zcatalog_unindex" />
+
   <subscriber handler=".subscribers.auto_catalog_object" />
   <subscriber handler=".subscribers.auto_uncatalog_object" />
 

--- a/eggs/Naaya/Products/NaayaCore/CatalogTool/patch_unindex_apply_index.py
+++ b/eggs/Naaya/Products/NaayaCore/CatalogTool/patch_unindex_apply_index.py
@@ -1,0 +1,177 @@
+""" Ported Unindex._apply_index from
+    Products.ZCatalog-2.13.27/Products/PluginIndexes/common/UnIndex.py
+    because it's a lot faster.
+"""
+import logging
+from cgi import escape
+
+from BTrees.IIBTree import intersection
+from BTrees.IIBTree import IISet
+from BTrees.IIBTree import multiunion
+
+from Products.PluginIndexes.common.util import parseIndexRequest
+
+from Products.PluginIndexes.common.UnIndex import UnIndex
+
+
+log = logging.getLogger(__name__)
+
+
+def patch_zcatalog_unindex():
+    old_apply_index = UnIndex._apply_index
+    UnIndex._apply_index = _apply_index
+    log.info('Applied UnIndex._apply_index patch!')
+
+
+def _apply_index(self, request, resultset=None):
+    """Apply the index to query parameters given in the request arg.
+
+    The request argument should be a mapping object.
+
+    If the request does not have a key which matches the "id" of
+    the index instance, then None is returned.
+
+    If the request *does* have a key which matches the "id" of
+    the index instance, one of a few things can happen:
+
+      - if the value is a blank string, None is returned (in
+	order to support requests from web forms where
+	you can't tell a blank string from empty).
+
+      - if the value is a nonblank string, turn the value into
+	a single-element sequence, and proceed.
+
+      - if the value is a sequence, return a union search.
+
+      - If the value is a dict and contains a key of the form
+	'<index>_operator' this overrides the default method
+	('or') to combine search results. Valid values are "or"
+	and "and".
+
+    If None is not returned as a result of the abovementioned
+    constraints, two objects are returned.  The first object is a
+    ResultSet containing the record numbers of the matching
+    records.  The second object is a tuple containing the names of
+    all data fields used.
+
+    FAQ answer:  to search a Field Index for documents that
+    have a blank string as their value, wrap the request value
+    up in a tuple ala: request = {'id':('',)}
+    """
+    record = parseIndexRequest(request, self.id, self.query_options)
+    if record.keys is None:
+	return None
+
+    index = self._index
+    r     = None
+    opr   = None
+
+    # experimental code for specifing the operator
+    operator = record.get('operator',self.useOperator)
+    if not operator in self.operators :
+	raise RuntimeError("operator not valid: %s" % escape(operator))
+
+    # Range parameter
+    range_parm = record.get('range',None)
+    if range_parm:
+	opr = "range"
+	opr_args = []
+	if range_parm.find("min")>-1:
+	    opr_args.append("min")
+	if range_parm.find("max")>-1:
+	    opr_args.append("max")
+
+    if record.get('usage',None):
+	# see if any usage params are sent to field
+	opr = record.usage.lower().split(':')
+	opr, opr_args=opr[0], opr[1:]
+
+    if opr=="range":   # range search
+	if 'min' in opr_args: lo = min(record.keys)
+	else: lo = None
+	if 'max' in opr_args: hi = max(record.keys)
+	else: hi = None
+	if hi:
+	    setlist = index.values(lo,hi)
+	else:
+	    setlist = index.values(lo)
+
+	# If we only use one key, intersect and return immediately
+	if len(setlist) == 1:
+	    result = setlist[0]
+	    if isinstance(result, int):
+		result = IISet((result,))
+	    return result, (self.id,)
+
+	if operator == 'or':
+	    tmp = []
+	    for s in setlist:
+		if isinstance(s, int):
+		    s = IISet((s,))
+		tmp.append(s)
+	    r = multiunion(tmp)
+	else:
+	    # For intersection, sort with smallest data set first
+	    tmp = []
+	    for s in setlist:
+		if isinstance(s, int):
+		    s = IISet((s,))
+		tmp.append(s)
+	    if len(tmp) > 2:
+		setlist = sorted(tmp, key=len)
+	    else:
+		setlist = tmp
+	    r = resultset
+	    for s in setlist:
+		# the result is bound by the resultset
+		r = intersection(r, s)
+
+    else: # not a range search
+	# Filter duplicates
+	setlist = []
+	for k in record.keys:
+	    s = index.get(k, None)
+	    # If None, try to bail early
+	    if s is None:
+		if operator == 'or':
+		    # If union, we can't possibly get a bigger result
+		    continue
+		# If intersection, we can't possibly get a smaller result
+		return IISet(), (self.id,)
+	    elif isinstance(s, int):
+		s = IISet((s,))
+	    setlist.append(s)
+
+	# If we only use one key return immediately
+	if len(setlist) == 1:
+	    result = setlist[0]
+	    if isinstance(result, int):
+		result = IISet((result,))
+	    return result, (self.id,)
+
+	if operator == 'or':
+	    # If we already get a small result set passed in, intersecting
+	    # the various indexes with it and doing the union later is
+	    # faster than creating a multiunion first.
+	    if resultset is not None and len(resultset) < 200:
+		smalllist = []
+		for s in setlist:
+		    smalllist.append(intersection(resultset, s))
+		r = multiunion(smalllist)
+	    else:
+		r = multiunion(setlist)
+	else:
+	    # For intersection, sort with smallest data set first
+	    if len(setlist) > 2:
+		setlist = sorted(setlist, key=len)
+	    r = resultset
+	    for s in setlist:
+		r = intersection(r, s)
+
+    if isinstance(r, int):
+	r = IISet((r, ))
+    if r is None:
+	return IISet(), (self.id,)
+    else:
+	return r, (self.id,)
+

--- a/eggs/Naaya/Products/NaayaCore/GeoMapTool/GeoMapTool.py
+++ b/eggs/Naaya/Products/NaayaCore/GeoMapTool/GeoMapTool.py
@@ -396,33 +396,47 @@ class GeoMapTool(Folder, utils, session_manager, symbols_tool):
         catalog_tool = self.getCatalogTool()
 
         # call the improved cluster_catalog function for getting the clusters
+        t0 = time.time()
         centers, groups = clusters_catalog.getClusters(catalog_tool, filters)
+        print('getClusters: {:.4f}'.format(time.time() - t0))
 
         # transform centers to Geo
         centers = map(lambda c: Geo(str(c.lat), str(c.lon)), centers)
+
+        d_lat_min, d_lat_max = Decimal(str(lat_min)), Decimal(str(lat_max))
+        d_lon_min, d_lon_max = Decimal(str(lon_min)), Decimal(str(lon_max))
+
+        _catalog = catalog_tool._catalog
+        idx_lat = _catalog.indexes['geo_latitude']._unindex
+        idx_lon = _catalog.indexes['geo_longitude']._unindex
+        idx_geo_type = _catalog.indexes['geo_type']._unindex
+
+        def get_brain_info(rid, b_lat=None, b_lon=None):
+            info = _catalog.getMetadataForRID(rid)
+            # info.update(_catalog.getIndexDataForRID(rid))
+            info['lat'] = b_lat or idx_lat[rid]
+            info['lon'] = b_lon or idx_lon[rid]
+            info['path'] = _catalog.paths[rid]
+            info['geo_type'] = idx_geo_type[rid]
+            return info
 
         cluster_obs, single_obs = [], []
         for i in range(len(centers)):
             if len(groups[i]) < 10:
                 # from this const on we actually return clusters
-                for so in groups[i]:
-                    sobject = clusters_catalog.getObjectFromCatalog(
-                        catalog_tool, so)
+                for rid in groups[i]:
+                    b_lat = idx_lat[rid]
+                    b_lon = idx_lon[rid]
 
                     # do not display it if it is not in the actual map
-                    if (Decimal(str(lat_min)) < sobject.geo_location.lat <
-                            Decimal(str(lat_max))):
-                        if (Decimal(str(lon_min)) < sobject.geo_location.lon <
-                                Decimal(str(lon_max))):
-                            single_obs.append(sobject)
+                    if (d_lat_min < b_lat < d_lat_max):
+                        if (d_lon_min < b_lon < d_lon_max):
+                            single_obs.append(get_brain_info(rid, b_lat, b_lon))
             else:
-                if (Decimal(str(lat_min)) < centers[i].lat <
-                        Decimal(str(lat_max))):
-                    if (Decimal(str(lon_min)) < centers[i].lon <
-                            Decimal(str(lon_max))):
+                if (d_lat_min < centers[i].lat < d_lat_max):
+                    if (d_lon_min < centers[i].lon < d_lon_max):
                         group_paths = [
-                            clusters_catalog.getObjectPathFromCatalog(
-                                catalog_tool, rid)
+                            _catalog.paths[rid]
                             for rid in groups[i]]
                         cluster_obs.append((centers[i], group_paths))
 
@@ -544,12 +558,12 @@ class GeoMapTool(Folder, utils, session_manager, symbols_tool):
                 if res.geo_location is None:
                     continue
                 points.append({
-                    'lat': res.geo_location.lat,
-                    'lon': res.geo_location.lon,
-                    'id': path_in_site(res),
-                    'label': res.title_or_id(),
-                    'icon_name': 'mk_%s' % res.geo_type,
-                    'tooltip': self.get_marker(res),
+                    'lat': res['lat'],
+                    'lon': res['lon'],
+                    'id': res['path'],
+                    'label': res['title'],
+                    'icon_name': 'mk_%s' % res['geo_type'],
+                    'tooltip': '' # self.get_marker(res),
                 })
 
             json_response = json.dumps({'points': points},
@@ -568,8 +582,11 @@ class GeoMapTool(Folder, utils, session_manager, symbols_tool):
         """ """
         try:
             points = []
+            t0 = time.time()
             cluster_obs, single_obs = self.search_geo_clusters(REQUEST)
+            print('Query: {:.4f}'.format(time.time() - t0))
 
+            t1 = time.time()
             for center, grouped_ids in cluster_obs:
                 points.append({
                     'lat': center.lat,
@@ -583,28 +600,37 @@ class GeoMapTool(Folder, utils, session_manager, symbols_tool):
                     'point_ids': grouped_ids,
                 })
 
+            print('Groups: {:.4f}'.format(time.time() - t1))
+
+            t2 = time.time()
             for res in single_obs:
-                if res.geo_location is None:
+                if not res['lat'] and not res['lon']:
                     continue
-                if not res.geo_type:
+                if not res['geo_type']:
                     # TODO: add logging?
                     continue
                 points.append({
-                    'lat': res.geo_location.lat,
-                    'lon': res.geo_location.lon,
-                    'id': path_in_site(res),
-                    'label': res.title_or_id(),
-                    'icon_name': 'mk_%s' % res.geo_type,
-                    'tooltip': self.get_marker(res),
+                    'lat': res['lat'],
+                    'lon': res['lon'],
+                    'id': res['path'],
+                    'label': res['title'],
+                    'icon_name': 'mk_%s' % res['geo_type'],
+                    'tooltip': '' # XXX: self.get_marker(res),
                 })
 
+            print('Points: {:.4f}'.format(time.time() - t2))
+
+            t3 = time.time()
             response_data = {'points': points}
+            print('Response data: {:.4f}'.format(time.time() - t3))
 
         except:
             self.log_current_error()
             response_data = {'error': err_info(), 'points': {}}
 
+        t4 = time.time()
         json_response = json.dumps(response_data, default=json_encode_helper)
+        print('Response data: {:.4f}'.format(time.time() - t4))
 
         REQUEST.RESPONSE.setHeader('Content-type', 'application/json')
         return json_response

--- a/eggs/Naaya/Products/NaayaCore/GeoMapTool/clusters_catalog.py
+++ b/eggs/Naaya/Products/NaayaCore/GeoMapTool/clusters_catalog.py
@@ -96,19 +96,19 @@ def getClusters(catalog_tool, filters):
 
         #this code is from the search function in the catalog implementation in Zope
         t0 = time()
-        for idx_name, query in f.items():
+        for idx_name in f:
+            t00 = time()
+            index = catalog.getIndex(idx_name)
+            print('Get index ({}): {:.4f}'.format(idx_name, time() - t00))
+            t00 = time()
             index = catalog.getIndex(idx_name)
             r = index._apply_index(f)
-        # for i in catalog.indexes.keys():
-        #     index = catalog.getIndex(i)
-        #     _apply_index = getattr(index, "_apply_index", None)
-        #     if _apply_index is None:
-        #         continue
-        #     r = _apply_index(f)
-
+            took = time() - t00
+            print('Apply index ({}): {:.4f}'.format(idx_name, took))
+            # if took > 0.5:
+            #     import pdb; pdb.set_trace()
             if r is not None:
-                import pdb; pdb.set_trace()
-                r, u = r
+                r, _ = r
                 w, rs_f = weightedIntersection(rs_f, r)
         print('Apply indexes: {:.4f}'.format(time() - t0))
 


### PR DESCRIPTION
Patched `UnIndex._apply_index` with the implementation used by `Products.ZCatalog-2.13.27`, it is ~7.5 times faster than the previous implementation.

Improved `clusters_catalog.getClusters` for faster `_apply_index_with_range_dict_results` queries. `multiunion` makes the difference.